### PR TITLE
sentiment score added

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -488,7 +488,7 @@ version = "8.1.8"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
     {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
@@ -1313,6 +1313,18 @@ files = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.4.2"
+description = "Lightweight pipelining with Python functions"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "joblib-1.4.2-py3-none-any.whl", hash = "sha256:06d478d5674cbc267e7496a410ee875abd68e4340feff4490bcb7afb88060ae6"},
+    {file = "joblib-1.4.2.tar.gz", hash = "sha256:2382c5816b2636fbd20a09e0f4e9dad4736765fdfb7dca582943b9c1366b3f0e"},
+]
+
+[[package]]
 name = "jsonpatch"
 version = "1.33"
 description = "Apply JSON-Patches (RFC 6902)"
@@ -1939,6 +1951,32 @@ files = [
     {file = "nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c"},
     {file = "nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe"},
 ]
+
+[[package]]
+name = "nltk"
+version = "3.9.1"
+description = "Natural Language Toolkit"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "nltk-3.9.1-py3-none-any.whl", hash = "sha256:4fa26829c5b00715afe3061398a8989dc643b92ce7dd93fb4585a70930d168a1"},
+    {file = "nltk-3.9.1.tar.gz", hash = "sha256:87d127bd3de4bd89a4f81265e5fa59cb1b199b27440175370f7417d2bc7ae868"},
+]
+
+[package.dependencies]
+click = "*"
+joblib = "*"
+regex = ">=2021.8.3"
+tqdm = "*"
+
+[package.extras]
+all = ["matplotlib", "numpy", "pyparsing", "python-crfsuite", "requests", "scikit-learn", "scipy", "twython"]
+corenlp = ["requests"]
+machine-learning = ["numpy", "python-crfsuite", "scikit-learn", "scipy"]
+plot = ["matplotlib"]
+tgrep = ["pyparsing"]
+twitter = ["twython"]
 
 [[package]]
 name = "nodeenv"
@@ -3274,6 +3312,26 @@ doc = ["reno", "sphinx"]
 test = ["pytest", "tornado (>=4.5)", "typeguard"]
 
 [[package]]
+name = "textblob"
+version = "0.19.0"
+description = "Simple, Pythonic text processing. Sentiment analysis, part-of-speech tagging, noun phrase parsing, and more."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "textblob-0.19.0-py3-none-any.whl", hash = "sha256:af6b8827886f1ee839a625f4865e5abb1584eae8db2259627b33a6a0b02ef19d"},
+    {file = "textblob-0.19.0.tar.gz", hash = "sha256:0a3d06a47cf7759441da3418c4843aed3797a998beba2108c6245a2020f83b01"},
+]
+
+[package.dependencies]
+nltk = ">=3.9"
+
+[package.extras]
+dev = ["pre-commit (>=3.5,<4.0)", "textblob[tests]", "tox"]
+docs = ["PyYAML (==6.0.2)", "sphinx (==8.0.2)", "sphinx-issues (==4.1.0)"]
+tests = ["numpy", "pytest"]
+
+[[package]]
 name = "tiktoken"
 version = "0.9.0"
 description = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
@@ -3892,4 +3950,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "fe797ce4ef88c52412738209b5fd51977cf228b95a614b1215460545228bd4d6"
+content-hash = "50b54da9268ebeb9d3f76afe529f8e141bbd7670ba3e3aafd523b0e1f5b3ce90"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "isort (>=6.0.1,<7.0.0)",
   "types-pyyaml (>=6.0.12.20250402,<7.0.0.0)",
   "psutil (>=7.0.0,<8.0.0)",
+  "textblob (>=0.19.0,<0.20.0)",
 ]
 
 [build-system]

--- a/red_agent/analysis/analysis.ipynb
+++ b/red_agent/analysis/analysis.ipynb
@@ -1,0 +1,177 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Column Comparison Analysis:\n",
+      "--------------------------------------------------\n",
+      "\n",
+      "Common Columns:\n",
+      "--------------------\n",
+      "✓ Agreed-conversation\n",
+      "✓ Agreed-topics\n",
+      "✓ Agreed-with\n",
+      "✓ Align-to-ecosystem-values\n",
+      "✓ Align-to-human-centric-values\n",
+      "✓ Disagreed-topics\n",
+      "✓ Disagreed-with\n",
+      "✓ Diverge-from-ecosystem-values\n",
+      "✓ Diverge-from-human-centric-values\n",
+      "✓ Ethical Soundness\n",
+      "✓ Harm-ecosystems\n",
+      "✓ Harm-humans\n",
+      "✓ Manageable-level-of-risk\n",
+      "✓ Neutral-risk\n",
+      "✓ No-risky-at-all\n",
+      "✓ Protect-ecosystems\n",
+      "✓ Protect-humans\n",
+      "✓ Reasonable\n",
+      "✓ Risk Assessment\n",
+      "✓ Risky\n",
+      "✓ Very-Risky\n",
+      "✓ character\n",
+      "✓ comment_number\n",
+      "\n",
+      "Columns Only in Old Format:\n",
+      "--------------------\n",
+      "- Agent-role\n",
+      "- Alignment-and-Divergence\n",
+      "- Justified-risk\n",
+      "- Mitigated-risk\n",
+      "- No-risk-to-justify\n",
+      "- Risk Justification\n",
+      "- Sentiment-analysis\n",
+      "- Unnamed: 0\n",
+      "- Warned-risk\n",
+      "- comment\n",
+      "- sentiment_score\n",
+      "- topic_discussion\n",
+      "\n",
+      "Columns Only in New Format:\n",
+      "--------------------\n",
+      "+ Agent's role\n",
+      "+ Alignment and Divergence\n",
+      "+ Sentiment analysis\n",
+      "+ Topic\n",
+      "\n",
+      "Summary:\n",
+      "Total common columns: 23\n",
+      "Columns only in old format: 12\n",
+      "Columns only in new format: 4\n"
+     ]
+    }
+   ],
+   "source": [
+    "new_format = pd.read_csv(\"/Users/beto/Documents/Projects/red-agent/logs/evaluation.csv\")\n",
+    "old_format = pd.read_csv(\"/Users/beto/Documents/Projects/red-agent/docs/reference/agent_conversations.csv\")\n",
+    "\n",
+    "old_columns = old_format.columns\n",
+    "new_columns = new_format.columns\n",
+    "# Print column comparison analysis\n",
+    "print(\"Column Comparison Analysis:\")\n",
+    "print(\"-\" * 50)\n",
+    "\n",
+    "# Find common and different columns\n",
+    "common_cols = set(old_columns).intersection(set(new_columns))\n",
+    "only_old_cols = set(old_columns).difference(set(new_columns))\n",
+    "only_new_cols = set(new_columns).difference(set(old_columns))\n",
+    "\n",
+    "# Print common columns\n",
+    "print(\"\\nCommon Columns:\")\n",
+    "print(\"-\" * 20)\n",
+    "for col in sorted(common_cols):\n",
+    "    print(f\"✓ {col}\")\n",
+    "\n",
+    "# Print columns only in old format\n",
+    "print(\"\\nColumns Only in Old Format:\")\n",
+    "print(\"-\" * 20)\n",
+    "for col in sorted(only_old_cols):\n",
+    "    print(f\"- {col}\")\n",
+    "\n",
+    "# Print columns only in new format\n",
+    "print(\"\\nColumns Only in New Format:\")\n",
+    "print(\"-\" * 20)\n",
+    "for col in sorted(only_new_cols):\n",
+    "    print(f\"+ {col}\")\n",
+    "\n",
+    "# Print summary\n",
+    "print(\"\\nSummary:\")\n",
+    "print(f\"Total common columns: {len(common_cols)}\")\n",
+    "print(f\"Columns only in old format: {len(only_old_cols)}\")\n",
+    "print(f\"Columns only in new format: {len(only_new_cols)}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['character', 'comment_number', 'Harm-humans', 'Protect-humans',\n",
+       "       'Harm-ecosystems', 'Protect-ecosystems', 'Ethical Soundness',\n",
+       "       'No-risky-at-all', 'Manageable-level-of-risk', 'Neutral-risk', 'Risky',\n",
+       "       'Very-Risky', 'Risk Assessment', 'Align-to-human-centric-values',\n",
+       "       'Diverge-from-human-centric-values', 'Align-to-ecosystem-values',\n",
+       "       'Diverge-from-ecosystem-values', 'Alignment and Divergence',\n",
+       "       'Agent's role', 'Reasonable', 'Agreed-with', 'Disagreed-with',\n",
+       "       'Agreed-conversation', 'Agreed-topics', 'Disagreed-topics',\n",
+       "       'Sentiment analysis', 'Topic'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "new_columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "red-agent-K-j91-vY-py3.10",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary by Sourcery

Replace LLM-based sentiment analysis with TextBlob and add a numerical sentiment score.

New Features:
- Introduce a numerical sentiment score (-1.0 to 1.0) to complement the existing sentiment label (Positive/Neutral/Negative).

Bug Fixes:
- Correct a field name typo (`Forster_risk` to `neutral_risk`) in the default `RiskAssessmentResponse` used during error handling.
- Ensure comment text is correctly extracted by removing agent prefixes before TextBlob processing.
- Handle potential errors during TextBlob processing with a fallback to a neutral sentiment score.
- Explicitly add 'Sentiment score' to output keys during initialization to ensure it's processed correctly.
- Fix the default sentiment analysis response to include the new score field when errors occur during LLM calls (though LLM call for sentiment is now removed).

Enhancements:
- Calculate sentiment using the `TextBlob` library, removing the reliance on an LLM for this specific task.
- Add validation to the `SentimentAnalysisResponse` to ensure score range and consistency between score and label.
- Update default responses and output handling to include the new sentiment score field.
- Update the evaluation transcript generation to include the sentiment score column mapping.
- Refine the keyword generation prompt slightly (Defense topic).

Build:
- Add `textblob` as a project dependency.
- Update `poetry.lock` file based on the new dependency.